### PR TITLE
Tests/login urls

### DIFF
--- a/backend/login/urls.py
+++ b/backend/login/urls.py
@@ -4,7 +4,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("login/", views.login.as_view()),
-    path("callback/", views.callback.as_view()),
-    path("me/", views.GetMyData.as_view()),
+    path("login/", views.login.as_view(), name="login"),
+    path("callback/", views.callback.as_view(), name="callback"),
+    path("me/", views.GetMyData.as_view(), name="get_my_data"),
 ]

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -1,7 +1,7 @@
 import factory
 
 from login.models import OsmUser
-from core.models import Dataset, AOI, Label, Model
+from core.models import Dataset, AOI, Label, Model, Training
 
 
 class OsmUserFactory(factory.django.DjangoModelFactory):
@@ -48,3 +48,16 @@ class ModelFactory(factory.django.DjangoModelFactory):
     name = "Test Model"
     created_by = factory.SubFactory(OsmUserFactory)
     status = -1
+
+
+class TrainingFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = Training
+
+    model = factory.SubFactory(ModelFactory)
+    status = "SUBMITTED"
+    zoom_level = [20, 21]
+    created_by = factory.SubFactory(OsmUserFactory)
+    epochs = 3
+    batch_size = 24

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -1,7 +1,7 @@
 import factory
 
 from login.models import OsmUser
-from core.models import Dataset, AOI, Label
+from core.models import Dataset, AOI, Label, Model
 
 
 class OsmUserFactory(factory.django.DjangoModelFactory):
@@ -37,3 +37,14 @@ class LabelFactory(factory.django.DjangoModelFactory):
 
     aoi = factory.SubFactory(AoiFactory)
     geom = "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"
+
+
+class ModelFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = Model
+
+    dataset = factory.SubFactory(DatasetFactory)
+    name = "Test Model"
+    created_by = factory.SubFactory(OsmUserFactory)
+    status = -1

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -1,0 +1,21 @@
+import factory
+
+from login.models import OsmUser
+from core.models import Dataset
+
+
+class OsmUserFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = OsmUser
+
+    username = "Test User"
+    osm_id = 123456
+
+
+class DatasetFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Dataset
+
+    name = "Test Dataset"
+    created_by = factory.SubFactory(OsmUserFactory)
+    status = -1

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -1,7 +1,7 @@
 import factory
 
 from login.models import OsmUser
-from core.models import Dataset, AOI, Label, Model, Training
+from core.models import Dataset, AOI, Label, Model, Training, Feedback
 
 
 class OsmUserFactory(factory.django.DjangoModelFactory):
@@ -61,3 +61,16 @@ class TrainingFactory(factory.django.DjangoModelFactory):
     created_by = factory.SubFactory(OsmUserFactory)
     epochs = 3
     batch_size = 24
+
+
+class FeedbackFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = Feedback
+
+    geom = "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"
+    training = factory.SubFactory(TrainingFactory)
+    zoom_level = 19
+    feedback_type = "TP"
+    user = factory.SubFactory(OsmUserFactory)
+    source_imagery = "https://test_data/hotosm/fAIr/"

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -1,9 +1,7 @@
 import factory
 
 from login.models import OsmUser
-from core.models import Dataset, AOI
-
-from django.contrib.gis.geos import GEOSGeometry
+from core.models import Dataset, AOI, Label
 
 
 class OsmUserFactory(factory.django.DjangoModelFactory):
@@ -27,6 +25,15 @@ class AoiFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = AOI
 
-    geom = GEOSGeometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))", srid=4326)
+    geom = "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"
     dataset = factory.SubFactory(DatasetFactory)
     label_status = -1
+
+
+class LabelFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = Label
+
+    aoi = factory.SubFactory(AoiFactory)
+    geom = "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -1,7 +1,7 @@
 import factory
 
 from login.models import OsmUser
-from core.models import Dataset, AOI, Label, Model, Training, Feedback
+from core.models import Dataset, AOI, Label, Model, Training, Feedback, FeedbackAOI
 
 
 class OsmUserFactory(factory.django.DjangoModelFactory):
@@ -74,3 +74,15 @@ class FeedbackFactory(factory.django.DjangoModelFactory):
     feedback_type = "TP"
     user = factory.SubFactory(OsmUserFactory)
     source_imagery = "https://test_data/hotosm/fAIr/"
+
+
+class FeedbackAoiFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = FeedbackAOI
+
+    training = factory.SubFactory(TrainingFactory)
+    geom = "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"
+    label_status = -1
+    source_imagery = "https://test_data/hotosm/"
+    user = factory.SubFactory(OsmUserFactory)

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -1,7 +1,16 @@
 import factory
 
 from login.models import OsmUser
-from core.models import Dataset, AOI, Label, Model, Training, Feedback, FeedbackAOI
+from core.models import (
+    Dataset,
+    AOI,
+    Label,
+    Model,
+    Training,
+    Feedback,
+    FeedbackAOI,
+    FeedbackLabel,
+)
 
 
 class OsmUserFactory(factory.django.DjangoModelFactory):
@@ -86,3 +95,12 @@ class FeedbackAoiFactory(factory.django.DjangoModelFactory):
     label_status = -1
     source_imagery = "https://test_data/hotosm/"
     user = factory.SubFactory(OsmUserFactory)
+
+
+class FeedbackLabelFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = FeedbackLabel
+
+    feedback_aoi = factory.SubFactory(FeedbackAoiFactory)
+    geom = "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -1,7 +1,9 @@
 import factory
 
 from login.models import OsmUser
-from core.models import Dataset
+from core.models import Dataset, AOI
+
+from django.contrib.gis.geos import GEOSGeometry
 
 
 class OsmUserFactory(factory.django.DjangoModelFactory):
@@ -19,3 +21,12 @@ class DatasetFactory(factory.django.DjangoModelFactory):
     name = "Test Dataset"
     created_by = factory.SubFactory(OsmUserFactory)
     status = -1
+
+
+class AoiFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = AOI
+
+    geom = GEOSGeometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))", srid=4326)
+    dataset = factory.SubFactory(DatasetFactory)
+    label_status = -1

--- a/backend/tests/test_core_model.py
+++ b/backend/tests/test_core_model.py
@@ -1,6 +1,12 @@
 from django.test import TestCase
 
-from .factories import DatasetFactory, OsmUserFactory, AoiFactory, LabelFactory
+from .factories import (
+    DatasetFactory,
+    OsmUserFactory,
+    AoiFactory,
+    LabelFactory,
+    ModelFactory,
+)
 
 
 class TestCoreModels(TestCase):
@@ -10,6 +16,7 @@ class TestCoreModels(TestCase):
         self.dataset = DatasetFactory(created_by=self.user)
         self.aoi = AoiFactory(dataset=self.dataset)
         self.label = LabelFactory(aoi=self.aoi)
+        self.model = ModelFactory(dataset=self.dataset, created_by=self.user)
 
     def test_dataset_creation(self):
         self.assertEqual(self.dataset.name, "Test Dataset")
@@ -21,3 +28,9 @@ class TestCoreModels(TestCase):
 
     def test_label_creation(self):
         self.assertEqual(self.label.aoi, self.aoi)
+
+    def test_model_creation(self):
+        self.assertEqual(self.model.name, "Test Model")
+        self.assertEqual(self.model.dataset, self.dataset)
+        self.assertEqual(self.model.created_by, self.user)
+        self.assertEqual(self.model.status, -1)

--- a/backend/tests/test_core_model.py
+++ b/backend/tests/test_core_model.py
@@ -6,6 +6,7 @@ from .factories import (
     AoiFactory,
     LabelFactory,
     ModelFactory,
+    TrainingFactory,
 )
 
 
@@ -17,6 +18,7 @@ class TestCoreModels(TestCase):
         self.aoi = AoiFactory(dataset=self.dataset)
         self.label = LabelFactory(aoi=self.aoi)
         self.model = ModelFactory(dataset=self.dataset, created_by=self.user)
+        self.training = TrainingFactory(model=self.model, created_by=self.user)
 
     def test_dataset_creation(self):
         self.assertEqual(self.dataset.name, "Test Dataset")
@@ -34,3 +36,11 @@ class TestCoreModels(TestCase):
         self.assertEqual(self.model.dataset, self.dataset)
         self.assertEqual(self.model.created_by, self.user)
         self.assertEqual(self.model.status, -1)
+
+    def test_training_creation(self):
+        self.assertEqual(self.training.model, self.model)
+        self.assertEqual(self.training.status, "SUBMITTED")
+        self.assertEqual(self.training.zoom_level, [20, 21])
+        self.assertEqual(self.training.created_by, self.user)
+        self.assertEqual(self.training.epochs, 3)
+        self.assertEqual(self.training.batch_size, 24)

--- a/backend/tests/test_core_model.py
+++ b/backend/tests/test_core_model.py
@@ -7,6 +7,7 @@ from .factories import (
     LabelFactory,
     ModelFactory,
     TrainingFactory,
+    FeedbackFactory,
 )
 
 
@@ -19,6 +20,7 @@ class TestCoreModels(TestCase):
         self.label = LabelFactory(aoi=self.aoi)
         self.model = ModelFactory(dataset=self.dataset, created_by=self.user)
         self.training = TrainingFactory(model=self.model, created_by=self.user)
+        self.feedback = FeedbackFactory(training=self.training, user=self.user)
 
     def test_dataset_creation(self):
         self.assertEqual(self.dataset.name, "Test Dataset")
@@ -44,3 +46,10 @@ class TestCoreModels(TestCase):
         self.assertEqual(self.training.created_by, self.user)
         self.assertEqual(self.training.epochs, 3)
         self.assertEqual(self.training.batch_size, 24)
+
+    def test_feedback_creation(self):
+        self.assertEqual(self.feedback.training, self.training)
+        self.assertEqual(self.feedback.zoom_level, 19)
+        self.assertEqual(self.feedback.feedback_type, "TP")
+        self.assertEqual(self.feedback.user, self.user)
+        self.assertEqual(self.feedback.source_imagery, "https://test_data/hotosm/fAIr/")

--- a/backend/tests/test_core_model.py
+++ b/backend/tests/test_core_model.py
@@ -1,13 +1,19 @@
 from django.test import TestCase
 
-from .factories import DatasetFactory, OsmUserFactory
+from .factories import DatasetFactory, OsmUserFactory, AoiFactory
 
 
 class TestCoreModels(TestCase):
 
-    def test_dataset_creation(self):
-        user = OsmUserFactory(username="Test User 2", osm_id=123)
-        dataset = DatasetFactory(created_by=user)
+    def setUp(self):
+        self.user = OsmUserFactory(username="Test User 2", osm_id=123)
+        self.dataset = DatasetFactory(created_by=self.user)
+        self.aoi = AoiFactory(dataset=self.dataset)
 
-        self.assertEqual(dataset.name, "Test Dataset")
-        self.assertEqual(dataset.created_by, user)
+    def test_dataset_creation(self):
+        self.assertEqual(self.dataset.name, "Test Dataset")
+        self.assertEqual(self.dataset.created_by, self.user)
+
+    def test_aoi_creation(self):
+        self.assertEqual(self.aoi.dataset, self.dataset)
+        self.assertEqual(self.aoi.label_status, -1)

--- a/backend/tests/test_core_model.py
+++ b/backend/tests/test_core_model.py
@@ -9,6 +9,7 @@ from .factories import (
     TrainingFactory,
     FeedbackFactory,
     FeedbackAoiFactory,
+    FeedbackLabelFactory,
 )
 
 
@@ -23,6 +24,7 @@ class TestCoreModels(TestCase):
         self.training = TrainingFactory(model=self.model, created_by=self.user)
         self.feedback = FeedbackFactory(training=self.training, user=self.user)
         self.feedbackAoi = FeedbackAoiFactory(training=self.training, user=self.user)
+        self.feedbackLabel = FeedbackLabelFactory(feedback_aoi=self.feedbackAoi)
 
     def test_dataset_creation(self):
         self.assertEqual(self.dataset.name, "Test Dataset")
@@ -61,3 +63,6 @@ class TestCoreModels(TestCase):
         self.assertEqual(self.feedbackAoi.label_status, -1)
         self.assertEqual(self.feedbackAoi.source_imagery, "https://test_data/hotosm/")
         self.assertEqual(self.feedbackAoi.user, self.user)
+
+    def test_feedbackLabel_creation(self):
+        self.assertEqual(self.feedbackLabel.feedback_aoi, self.feedbackAoi)

--- a/backend/tests/test_core_model.py
+++ b/backend/tests/test_core_model.py
@@ -8,6 +8,7 @@ from .factories import (
     ModelFactory,
     TrainingFactory,
     FeedbackFactory,
+    FeedbackAoiFactory,
 )
 
 
@@ -21,6 +22,7 @@ class TestCoreModels(TestCase):
         self.model = ModelFactory(dataset=self.dataset, created_by=self.user)
         self.training = TrainingFactory(model=self.model, created_by=self.user)
         self.feedback = FeedbackFactory(training=self.training, user=self.user)
+        self.feedbackAoi = FeedbackAoiFactory(training=self.training, user=self.user)
 
     def test_dataset_creation(self):
         self.assertEqual(self.dataset.name, "Test Dataset")
@@ -53,3 +55,9 @@ class TestCoreModels(TestCase):
         self.assertEqual(self.feedback.feedback_type, "TP")
         self.assertEqual(self.feedback.user, self.user)
         self.assertEqual(self.feedback.source_imagery, "https://test_data/hotosm/fAIr/")
+
+    def test_feedbackAoi_creation(self):
+        self.assertEqual(self.feedbackAoi.training, self.training)
+        self.assertEqual(self.feedbackAoi.label_status, -1)
+        self.assertEqual(self.feedbackAoi.source_imagery, "https://test_data/hotosm/")
+        self.assertEqual(self.feedbackAoi.user, self.user)

--- a/backend/tests/test_core_model.py
+++ b/backend/tests/test_core_model.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+
+from .factories import DatasetFactory, OsmUserFactory
+
+
+class TestCoreModels(TestCase):
+
+    def test_dataset_creation(self):
+        user = OsmUserFactory(username="Test User 2", osm_id=123)
+        dataset = DatasetFactory(created_by=user)
+
+        self.assertEqual(dataset.name, "Test Dataset")
+        self.assertEqual(dataset.created_by, user)

--- a/backend/tests/test_core_model.py
+++ b/backend/tests/test_core_model.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from .factories import DatasetFactory, OsmUserFactory, AoiFactory
+from .factories import DatasetFactory, OsmUserFactory, AoiFactory, LabelFactory
 
 
 class TestCoreModels(TestCase):
@@ -9,6 +9,7 @@ class TestCoreModels(TestCase):
         self.user = OsmUserFactory(username="Test User 2", osm_id=123)
         self.dataset = DatasetFactory(created_by=self.user)
         self.aoi = AoiFactory(dataset=self.dataset)
+        self.label = LabelFactory(aoi=self.aoi)
 
     def test_dataset_creation(self):
         self.assertEqual(self.dataset.name, "Test Dataset")
@@ -17,3 +18,6 @@ class TestCoreModels(TestCase):
     def test_aoi_creation(self):
         self.assertEqual(self.aoi.dataset, self.dataset)
         self.assertEqual(self.aoi.label_status, -1)
+
+    def test_label_creation(self):
+        self.assertEqual(self.label.aoi, self.aoi)

--- a/backend/tests/test_login_model.py
+++ b/backend/tests/test_login_model.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+from login.models import OsmUser
+
+
+class TestLoginModels(TestCase):
+
+    def test_OsmUser_creation(self):
+        osm_user = OsmUser.objects.create(username="Test User", osm_id=123456)
+
+        self.assertEqual(str(osm_user), "Test User")
+        self.assertEqual(osm_user.osm_id, 123456)

--- a/backend/tests/test_login_model.py
+++ b/backend/tests/test_login_model.py
@@ -1,11 +1,12 @@
 from django.test import TestCase
-from login.models import OsmUser
+
+from .factories import OsmUserFactory
 
 
 class TestLoginModels(TestCase):
 
     def test_OsmUser_creation(self):
-        osm_user = OsmUser.objects.create(username="Test User", osm_id=123456)
+        osm_user = OsmUserFactory()
 
         self.assertEqual(str(osm_user), "Test User")
         self.assertEqual(osm_user.osm_id, 123456)

--- a/backend/tests/test_urls.py
+++ b/backend/tests/test_urls.py
@@ -1,0 +1,19 @@
+from django.test import SimpleTestCase
+from django.urls import reverse, resolve
+
+from login.views import login, callback, GetMyData
+
+
+class TestUrls(SimpleTestCase):
+
+    def test_login_url(self):
+        url = reverse("login")
+        self.assertEqual(resolve(url).func.view_class, login)
+
+    def test_callback_url(self):
+        url = reverse("callback")
+        self.assertEqual(resolve(url).func.view_class, callback)
+
+    def test_me_url(self):
+        url = reverse("get_my_data")
+        self.assertEqual(resolve(url).func.view_class, GetMyData)


### PR DESCRIPTION
### What does this PR do?
Adds login URLs tests 🎉

- I added tests for _**login url**_,  _**callback url**_, and  _**me url**_
- Contributes to resolving this issue: https://github.com/hotosm/fAIr/issues/229

### Consideration?
- Although coverage didn't pick this as something to test, I added tests for this(URL) as it as it is essential to have
- I used Black formatter
- I didn't add _coverage_ to the requirement file. So to check coverage, you have to install it yourself:
    - `pip install coverage`

### How to test?
- Clone this repo
- Follow the installation guide
- run `docker exec -it api bash` to run the following commands in the container:
   - `coverage run --omit='*/usr/*' manage.py test tests.test_urls`
   - or just `coverage run manage.py test tests.test_urls`
   - `coverage report` (to see a report of the test coverage)